### PR TITLE
Add support for datasets

### DIFF
--- a/test/vega_lite_test.exs
+++ b/test/vega_lite_test.exs
@@ -144,6 +144,41 @@ defmodule VegaLiteTest do
     end
   end
 
+  describe "datasets_from_values/2" do
+    test "adds normalized data values to the specification" do
+      data1 = [
+        %{"height" => 170, "weight" => 80},
+        %{"height" => 190, "weight" => 85}
+      ]
+
+      data2 = [
+        %{height: 170, weight: 80},
+        [height: 190, weight: 85]
+      ]
+
+      vl = Vl.new() |> Vl.datasets_from_values(data1: data1, data2: data2)
+
+      expected_vl =
+        Vl.from_json("""
+        {
+          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+          "datasets": {
+            "data1": [
+              { "height": 170, "weight": 80 },
+              { "height": 190, "weight": 85 }
+            ],
+            "data2": [
+              { "height": 170, "weight": 80 },
+              { "height": 190, "weight": 85 }
+            ]
+          }
+        }
+        """)
+
+      assert vl == expected_vl
+    end
+  end
+
   describe "encode/3" do
     test "raises an error when invalid channel is given" do
       assert_raise ArgumentError, fn ->


### PR DESCRIPTION
Closes #16.

@dustinfarris if you have a use case for this feature, please test this branch and let me know if it gets you where you need :)

```elixir
{:vega_lite, "~> 0.1.1", github: "livebook-dev/vega_lite", branch: "jk-datasets", override: true}
```

Example usage alternative to `data_from_values`:

```elixir
Vl.new(width: 400, height: 400)
|> Vl.datasets_from_values(
  mydata: [
    %{iteration: 1, score: 1},
    %{iteration: 10, score: 10},
    %{iteration: 100, score: 100}
  ]
)
|> Vl.data(name: "mydata")
|> Vl.mark(:line)
|> Vl.encode_field(:x, "iteration", type: :quantitative)
|> Vl.encode_field(:y, "score", type: :quantitative)
```