### PR TITLE
Add offset channels.

### DIFF
--- a/lib/vega_lite.ex
+++ b/lib/vega_lite.ex
@@ -368,6 +368,7 @@ defmodule VegaLite do
 
   @channels ~w(
     x y x2 y2 x_error y_error x_error2 y_error2
+    x_offset y_offset
     theta theta2 radius radius2
     longitude latitude longitude2 latitude2
     angle color fill stroke opacity fill_opacity stroke_opacity shape size stroke_dash stroke_width

--- a/lib/vega_lite/export.ex
+++ b/lib/vega_lite/export.ex
@@ -86,9 +86,9 @@ defmodule VegaLite.Export do
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Vega-Lite graphic</title>
-      <script src="https://cdn.jsdelivr.net/npm/vega@5.20.2"></script>
-      <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.1.0"></script>
-      <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.17.0"></script>
+      <script src="https://cdn.jsdelivr.net/npm/vega@5.21.0"></script>
+      <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.2.0"></script>
+      <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.20.5"></script>
     </head>
     <body>
       <div id="graphic"></div>


### PR DESCRIPTION
# Why
New version of vega-lite [v5.2.0](git@github.com:livebook-dev/vega_lite.git) introduced support offset channel.

The channels are `xOffset` and `yOffset` (https://vega.github.io/vega-lite/docs/encoding.html#channels and https://vega.github.io/vega-lite/docs/encoding.html#positon-offset).

The [example](https://vega.github.io/vega-lite/examples/bar_grouped_repeated.html) in documentation

## This PR is:
- adding `x_offset` and `y_offset` into list for channel validating
- update scripts dependencies `vega`, `vega-lite` and `vega-embed` to most recent versions (all minors updates)

#### Note
It seems in some cases we could use `Vl.encode_field(:color, "gender")`, but if related data are not `nominal`, but `quantitative` we need that offset channel.

