### PR TITLE
Use table reader in data_from_values/3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule VegaLite.MixProject do
   defp deps do
     [
       {:jason, "~> 1.2", only: [:dev, :test]},
+      {:table, "~> 0.1.0"},
       {:ex_doc, "~> 0.24", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "table": {:hex, :table, "0.1.0", "f16104d717f960a623afb134a91339d40d8e11e0c96cfce54fee086b333e43f0", [:mix], [], "hexpm", "bf533d3606823ad8a7ee16f41941e5e6e0e42a20c4504cdf4cfabaaed1c8acb9"},
 }

--- a/test/vega_lite_test.exs
+++ b/test/vega_lite_test.exs
@@ -96,7 +96,7 @@ defmodule VegaLiteTest do
 
     test "converts key-value data structures to value entries" do
       data = [
-        %{height: 170, weight: 80},
+        [height: 170, weight: 80],
         [height: 190, weight: 85]
       ]
 
@@ -117,14 +117,12 @@ defmodule VegaLiteTest do
 
       assert vl == expected_vl
     end
-  end
 
-  describe "data_from_series/3" do
-    test "adds data values to the specification" do
+    test "supports series" do
       iterations = 1..3
       scores = [50, 60, 90]
 
-      vl = Vl.new() |> Vl.data_from_series(iteration: iterations, score: scores)
+      vl = Vl.new() |> Vl.data_from_values(iteration: iterations, score: scores)
 
       expected_vl =
         Vl.from_json("""
@@ -135,6 +133,30 @@ defmodule VegaLiteTest do
               { "iteration": 1, "score": 50 },
               { "iteration": 2, "score": 60 },
               { "iteration": 3, "score": 90 }
+            ]
+          }
+        }
+        """)
+
+      assert vl == expected_vl
+    end
+
+    test "inludes partial data if the :only option is specified" do
+      data = [
+        %{"height" => 170, "weight" => 80, "score" => 50},
+        %{"height" => 190, "weight" => 85, "score" => 55}
+      ]
+
+      vl = Vl.new() |> Vl.data_from_values(data, only: ["height", "weight"])
+
+      expected_vl =
+        Vl.from_json("""
+        {
+          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+          "data": {
+            "values": [
+              { "height": 170, "weight": 80 },
+              { "height": 190, "weight": 85 }
             ]
           }
         }
@@ -156,7 +178,9 @@ defmodule VegaLiteTest do
         [height: 190, weight: 85]
       ]
 
-      vl = Vl.new() |> Vl.datasets_from_values(data1: data1, data2: data2)
+      data3 = %{iteration: 1..3, score: [50, 60, 90]}
+
+      vl = Vl.new() |> Vl.datasets_from_values(data1: data1, data2: data2, data3: data3)
 
       expected_vl =
         Vl.from_json("""
@@ -170,6 +194,11 @@ defmodule VegaLiteTest do
             "data2": [
               { "height": 170, "weight": 80 },
               { "height": 190, "weight": 85 }
+            ],
+            "data3": [
+              { "iteration": 1, "score": 50 },
+              { "iteration": 2, "score": 60 },
+              { "iteration": 3, "score": 90 }
             ]
           }
         }


### PR DESCRIPTION
Extends `data_from_values` to support `Table.Reader.t()` and deprecates `data_from_series`, as it is also covered by `data_from_values`.