### PR TITLE
Makes columns_for public

### DIFF
--- a/lib/vega_lite/data.ex
+++ b/lib/vega_lite/data.ex
@@ -324,7 +324,11 @@ defmodule VegaLite.Data do
 
   ## Infer types
 
-  defp columns_for(data) do
+  @doc """
+  Returns a map with each column and its respective inferred type for a given data
+  """
+  @spec columns_for(Table.Reader.t()) :: map() | nil
+  def columns_for(data) do
     with true <- implements?(Table.Reader, data),
          data = {_, %{columns: [_ | _] = columns}, _} <- Table.Reader.init(data),
          true <- Enum.all?(columns, &implements?(String.Chars, &1)) do

--- a/lib/vega_lite/data.ex
+++ b/lib/vega_lite/data.ex
@@ -325,7 +325,7 @@ defmodule VegaLite.Data do
   ## Infer types
 
   @doc """
-  Returns a map with each column and its respective inferred type for a given data
+  Returns a map with each column and its respective inferred type for the given data.
   """
   @spec columns_for(Table.Reader.t()) :: map() | nil
   def columns_for(data) do


### PR DESCRIPTION
I think that makes more sense to open `columns_for ` instead of `infer_types`. WDYT @josevalim?